### PR TITLE
Oct2023 security update

### DIFF
--- a/matugr/build.gradle
+++ b/matugr/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 
     // OkHttp
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.9.0"))
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:logging-interceptor")
 


### PR DESCRIPTION
Updating OkHttp library to address vulnerabilities:

See vulnerabilities for OkHttp 4.9.0:
https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.9.0

Updating to OkHttp 4.10.0
https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.10.0