### PR TITLE
Oct2023 bump okhttp version to address okio vulnerability

### DIFF
--- a/matugr/build.gradle
+++ b/matugr/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"
 
     // OkHttp
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.12.0"))
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:logging-interceptor")
 


### PR DESCRIPTION
OkHttp 4.10.0 ---> okio | 3.0.0 
[CVE-2023-3635](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3635)

Bump to 4.12.0 ---> okio | 3.6.0

See: https://mvnrepository.com/artifact/com.squareup.okio/okio