### PR TITLE
Update moshi and okio versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.kotlin_version = "1.8.21"
     ext.dagger_version = '2.45'
-    ext.moshi_version = '1.14.0'
+    ext.moshi_version = '1.15.0'
     ext.coroutines_version = '1.6.4'
     ext.lifecycle_version = '1.1.1'
     ext.hilt_version = '2.43.2'

--- a/matugr/build.gradle
+++ b/matugr/build.gradle
@@ -77,6 +77,13 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
 
+    // okio
+    implementation("com.squareup.okio:okio") {
+        version {
+            strictly '3.6.0' // free of CVE-2023-3635
+        }
+    }
+
     // Moshi
     implementation "com.squareup.moshi:moshi:$moshi_version"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshi_version"


### PR DESCRIPTION
Updating moshi to latest version

Forcing a strict version okio (3.6.0) - See [CVE-2023-3635](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3635) and [okio maven](https://mvnrepository.com/artifact/com.squareup.okio/okio)

[master in Moshi currently contains okio (3.6.0)](https://github.com/square/moshi/blob/64196346f09b24c07831f6880b4e825c2ebb0403/gradle/libs.versions.toml#L35)